### PR TITLE
Add a ratio to "res/config.json"

### DIFF
--- a/res/config.json
+++ b/res/config.json
@@ -1,5 +1,9 @@
 {   
     "AspectRatios": {
+    "683:384": {
+        "Width": 1366,
+        "Height": 768
+    },
 	"16:9": {
 	    "Width": 832,
 	    "Height": 468


### PR DESCRIPTION
Hello,

I had to add the ratio of my screen resolution so that the program could run correctly.

I therefore propose to add it, as evanbowman suggested to me.