### PR TITLE
Windows crashing on currentDir calc fix.

### DIFF
--- a/src/Laika.hpp
+++ b/src/Laika.hpp
@@ -195,9 +195,15 @@ public:
                 path.pop_back();
                 position.x = ((position.x - tiles.posX) / 32) * 32 + tiles.posX;
                 position.y = ((position.y - tiles.posY) / 26) * 26 + tiles.posY;
-                currentDir = atan2(
-                    position.y - (((path.back().y * 26) + 4 + tiles.posY)),
-                    position.x - (((path.back().x * 32) + 4 + tiles.posX)));
+				
+				// Same as Critter, this causes a crash when finishing a path, and
+				// calculating the currentDirection...
+				
+                if (!path.empty()) {
+					currentDir = atan2(
+						position.y - (((path.back().y * 26) + 4 + tiles.posY)),
+						position.x - (((path.back().x * 32) + 4 + tiles.posX)));
+				}
             }
         } else {
             position.x -= speed * cos(currentDir) *
@@ -210,9 +216,11 @@ public:
                     8) {
                 recalc--;
                 path.pop_back();
-                currentDir = atan2(
-                    position.y - (((path.back().y * 26) + 4 + tiles.posY)),
-                    position.x - (((path.back().x * 32) + 4 + tiles.posX)));
+                if (!path.empty()) {
+					currentDir = atan2(
+						position.y - (((path.back().y * 26) + 4 + tiles.posY)),
+						position.x - (((path.back().x * 32) + 4 + tiles.posX)));
+				}
             }
         }
     }

--- a/src/critter.cpp
+++ b/src/critter.cpp
@@ -101,9 +101,11 @@ void Critter::update(Game * pGame, const sf::Time & elapsedTime,
                 // Calculate the direction to move in, based on the coordinate
                 // of the previous location and the coordinate of the next
                 // location
-                currentDir =
-                    atan2(yInit - (((path.back().y * 26) + 4 + tilePosY)),
-                          xInit - (((path.back().x * 32) + 4 + tilePosX)));
+                if (!path.empty()) {
+					currentDir =
+						atan2(yInit - (((path.back().y * 26) + 4 + tilePosY)),
+							xInit - (((path.back().x * 32) + 4 + tilePosX)));
+				}
             }
         } else if (!path.empty()) {
             // Add each component of the direction vector to the enemy's
@@ -119,10 +121,22 @@ void Critter::update(Game * pGame, const sf::Time & elapsedTime,
                 recalc--;
                 previous = path.back();
                 path.pop_back();
-                // Calculate the direction to move in
-                currentDir =
-                    atan2(yInit - (((path.back().y * 26) + 4 + tilePosY)),
-                          xInit - (((path.back().x * 32) + 4 + tilePosX)));
+
+				// For some weird reason, on windows, the path somewhere gets GC-d (Garbage Collected) or something like that,
+				// because the var previous ain't clear, but path.back() is COMPLETELY clear...
+				// I tried using 'previous' as the argument to yInit and xInit, but that's completely different, maybe it gets
+				// GC-d beforehand? Although this only happens when the path is finished (Walked to last player position), and
+				// tries to set up a new direction. That might explain, this but what it won't is why it's empty, on the second
+				// #back()...
+				// I know for sure it's on Windows, cause I had 2 pc's test this, and both returned same errors
+				// So I guess it's a temporary fix, that works...
+
+				if (!path.empty()) {
+                    // Calculate the direction to move in
+                    currentDir = atan2(
+				        yInit - (((path.back().y * 26) + 4 + tilePosY)),
+			            xInit - (((path.back().x * 32) + 4 + tilePosX)));
+                }
             }
         }
 


### PR DESCRIPTION
I think I've tracked down the problem... The problem was the following:
So you know the currentDir gets calculated, and everything is great until Windows decides he's an absolute a**hole and GC's the path variable. This causes it to be null, essentially clear, and sometimes it happens between the previous var and the currentDir's atan2... so if we add a quick little path.empty check to see if it's clear or not, we immediately filter out Windows' bulls**t! This worked for me, hope it works for others on Windows.